### PR TITLE
Fix color overflow.

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -327,8 +327,8 @@ short find_add_pair(const short fg, const short bg) { /* {{{ */
      */
     short tmpfg;
     short tmpbg;
-    short pair;
-    short free_pair = -1;
+    int pair;
+    int free_pair = -1;
     int   ret;
 
     /* look for an existing pair */


### PR DESCRIPTION
COLOR_PAIRS can be sufficiently large that a short will overflow when
iterating over the colors. This means we never break out of the loop.
Changing to int fixes this.